### PR TITLE
Update git packaging

### DIFF
--- a/packages/git/packaging
+++ b/packages/git/packaging
@@ -1,6 +1,6 @@
 set -e -x
 
-
+apt-get update -y
 apt-get install automake libexpat1-dev libz-dev gettext curl -y
 
 export VERSION=2.3.0


### PR DESCRIPTION
The `bosh-warden-boshlite-ubuntu-trusty-go_agent` version 3147 fails with:

```
Get:3 http://archive.ubuntu.com/ubuntu/ trusty/main automake all 1:1.14.1-2ubuntu1 [510 kB]
Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main libexpat1-dev amd64 2.1.0-4ubuntu1.1
  404  Not Found [IP: 91.189.88.161 80]
Err http://security.ubuntu.com/ubuntu/ trusty-security/main libexpat1-dev amd64 2.1.0-4ubuntu1.1
  404  Not Found [IP: 91.189.88.161 80]
Fetched 877 kB in 0s (976 kB/s)
, Stderr: + apt-get install automake libexpat1-dev libz-dev gettext curl -y
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/e/expat/libexpat1-dev_2.1.0-4ubuntu1.1_amd64.deb  404  Not Found [IP: 91.189.88.161 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
