### PR TITLE
Set Gogs SSH configurable, port 2222 by default

### DIFF
--- a/jobs/gogs/spec
+++ b/jobs/gogs/spec
@@ -28,6 +28,9 @@ properties:
   gogs.protocol:
     descripton: "http or https for gogs web"
     default: 'http'
+  gogs.ssh_port:
+    description: "Port for Gogs SSH"
+    default: '2222'
   gogs.admin:
     description: "Admin user for gogs"
     default: 'gogs'

--- a/jobs/gogs/templates/config/app.ini.erb
+++ b/jobs/gogs/templates/config/app.ini.erb
@@ -15,7 +15,7 @@ HTTP_PORT = <%= p("gogs.port") %>
 <% db_role = p("databases.roles").find { |role| role["tag"] == "gogs" } %>
 ROOT_URL = <%= p("gogs.protocol")%>://<%= p("gogs.domain")%>
 DISABLE_SSH = false
-SSH_PORT = 22
+SSH_PORT = <%= p("gogs.ssh_port") %>
 SSH_ROOT_PATH = /var/vcap/store/gogs/home/.ssh
 START_SSH_SERVER = false
 OFFLINE_MODE = false


### PR DESCRIPTION
sshd of stemcell  is already listened on 22. Gogs SSH will listen on 2222 by default.