### PR TITLE
Git client packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ blobs/*
 #*
 tmp
 my*.yml
+
+*.iml

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,6 @@
-git/git-v2.3.0.tar.gz:
-  size: 5168085
-  object_id: 2bcdc2e0-e8a2-4a55-b266-55689c77cad2
-  sha: ae668cef3b9a4955f496ce41fefb058b5368d52f
+git/git-2.18.0.tar.gz:
+  size: 7498807
+  sha: a7687c34d308b0e3d566a7d083edaca5fa92f834
 gogs/gogs_linux_amd64_v0.11.53.tar.gz:
   size: 19322398
   object_id: bb0fe477-dfda-4bb5-6ea0-9462dbb2826c

--- a/jobs/gogs/spec
+++ b/jobs/gogs/spec
@@ -48,6 +48,9 @@ properties:
   gogs.tls_key:
     description: "Private key TLS for gogs web"
 
+  databases.type:
+    description: "The database type you choose, either mysql, postgres, mssql or sqlite3."
+    default: postgres
   databases.port:
     description: "The database port"
     default: 5432

--- a/jobs/gogs/templates/config/app.ini.erb
+++ b/jobs/gogs/templates/config/app.ini.erb
@@ -27,7 +27,7 @@ KEY_FILE=/var/vcap/jobs/gogs/config/gogs.key
 <% end -%>
 
 [database]
-DB_TYPE = postgres
+DB_TYPE = <%= p("databases.type") %>
 HOST = <%= p("databases.address") %>:<%= p("databases.port") %>
 NAME = <%= db["name"] %>
 USER = <%= db_role["name"] %>

--- a/packages/git/packaging
+++ b/packages/git/packaging
@@ -1,17 +1,7 @@
-set -e -x
+set -ex
 
-apt-get update -y
-apt-get install automake libexpat1-dev libz-dev gettext curl -y
-
-export VERSION=2.3.0
-
-cd git
-
-tar -zxf git-v${VERSION}.tar.gz
-
-cd git-${VERSION}
-
-make configure
-./configure  --prefix=${BOSH_INSTALL_TARGET} CFLAGS="${CFLAGS} -static" NO_OPENSSL=1 NO_CURL=1
-make
+tar -xzvf git/git-2.18.0.tar.gz
+cd git-2.18.0
+./configure --prefix=${BOSH_INSTALL_TARGET}
+make all
 make install


### PR DESCRIPTION
 - update git client version 
 -- requires new blob added to blobstore from [https://mirrors.edge.kernel.org/pub/software/scm/git/](url)
 -- direct link to blob [https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.18.0.tar.gz](url)
 - update git client packaging
 - add database type as configuration property

gh-18