### PR TITLE
Move gogs admin user creation into its own errand

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ open https://gogs.v3.pcfdev.io/user/sign_up
 ```
 
 Note: `--vars-store creds.yml` is not required if your BOSH environment is configured with Credhub.
+
+## Post Deploy Errand
+To create an admin user after deploying GOGS, run the following errand.
+
+This was moved from the `gogs_ctl` script to this errand as it was never executed previously
+```
+bosh -d gogs run-errand gogs-admin
+```

--- a/jobs/gogs-admin/spec
+++ b/jobs/gogs-admin/spec
@@ -1,0 +1,17 @@
+---
+name: gogs-admin
+
+templates:
+  run.sh.erb: bin/run
+
+packages: []
+
+properties:
+  gogs.admin:
+    description: "Admin user for gogs"
+    default: 'gogs'
+  gogs.password:
+    description: "Password for admin user"
+  gogs.email:
+    description: "Email for admin account"
+    default: 'admin@example.com'

--- a/jobs/gogs-admin/templates/run.sh.erb
+++ b/jobs/gogs-admin/templates/run.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export PACKAGE_DIR=/var/vcap/packages/gogs
+export STORE_DIR=/var/vcap/store/gogs
+
+# Create admin user for the initial
+su - git -c "${PACKAGE_DIR}/gogs admin create-user \
+  --name <%= p('gogs.admin') %> \
+  --password <%= p('gogs.password') %> \
+  --email <%= p('gogs.email') %> \
+  --admin \
+  --config ${STORE_DIR}/config/app.ini"

--- a/jobs/gogs/spec
+++ b/jobs/gogs/spec
@@ -33,14 +33,6 @@ properties:
   gogs.start_ssh_server:
     description: "Start SSH Server"
     default: "true"
-  gogs.admin:
-    description: "Admin user for gogs"
-    default: 'gogs'
-  gogs.password:
-    description: "Password for admin user"
-  gogs.email:
-    description: "Email for admin account"
-    default: 'admin@example.com'
   gogs.secret_key:
     description: "Global secret key for your server security"
   gogs.tls_cert:

--- a/jobs/gogs/templates/bin/gogs_ctl
+++ b/jobs/gogs/templates/bin/gogs_ctl
@@ -56,14 +56,6 @@ case $1 in
          >>$LOG_DIR/$JOB_NAME.stdout.log \
          2>>$LOG_DIR/$JOB_NAME.stderr.log
 
-    # Create admin user for the initial
-    su git -c "${PACKAGE_DIR}/gogs admin create-user \
-		      --name <%= p('gogs.admin') %> \
-		      --password <%= p('gogs.password') %> \
-		      --email <%= p('gogs.email') %> \
-                      --admin \
-		      --config ${STORE_DIR}/config/app.ini"
-
     ;;
 
   stop)

--- a/manifests/gogs.yml
+++ b/manifests/gogs.yml
@@ -14,6 +14,8 @@ instance_groups:
     release: gogs
   - name: gogs
     release: gogs
+  - name: gogs-admin
+    release: gogs
 - name: sanity-test
   azs: [z1]
   instances: 1


### PR DESCRIPTION
When I went to use this bosh release, I found the admin user was not being created. #20 mentions this too
This moves the creation of the admin account out of `gogs_ctl` and into its own errand.

I will also have follow up PR coming which adds the ability to specify authentication backends (LDAP, SMTP) which means this account creation can be optional.