### PR TITLE
Add ability to specify different authentication backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ bosh -d gogs run-errand gogs-admin
 ## Deploy with Authentication Backends
 You can deploy gogs with alternative authentication backends.
 
-The supported backend types are available [on the gogs website](https://gogs.io/docs/features/authentication) with examples for each [here](https://github.com/gogs/gogs/tree/f2ecfdc96a338815ffb2be898b3114031f0da48c/conf/auth.d).
+The supported backend types are available [on the gogs website](https://gogs.io/docs/features/authentication) with examples of the configuration options each have [here](https://github.com/gogs/gogs/tree/f2ecfdc96a338815ffb2be898b3114031f0da48c/conf/auth.d).
 
-You can modify the operators files with multiple backends for each type, and using the examples in the gogs repository, and the example operators in this repository you can see how to add them. You can also add multiple backends of the same type
+Using the configuration options examples, and the operator files in `manifests/operators` in this repository, you can craft different backends to use.
+
+Deploy example with operator file:
 ```
 bosh -d gogs deploy gogs-boshrelease/manifests/gogs.yml \
-  -o gogs-boshrelease/manifests/operators/ldap_auth.yml \
+  -o gogs-boshrelease/manifests/operators/ldap-auth.yml \
   -v gogs-uri=gogs.v3.pcf.dev.io \
   --vars-store creds.yml
 ```
+It is possible to specify multiple backends of the same type, see `manifests/operators/ldap-auth-multiple.yml` for an example.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ This was moved from the `gogs_ctl` script to this errand as it was never execute
 ```
 bosh -d gogs run-errand gogs-admin
 ```
+
+## Deploy with Authentication Backends
+You can deploy gogs with alternative authentication backends.
+
+The supported backend types are available [on the gogs website](https://gogs.io/docs/features/authentication) with examples for each [here](https://github.com/gogs/gogs/tree/f2ecfdc96a338815ffb2be898b3114031f0da48c/conf/auth.d).
+
+You can modify the operators files with multiple backends for each type, and using the examples in the gogs repository, and the example operators in this repository you can see how to add them. You can also add multiple backends of the same type
+```
+bosh -d gogs deploy gogs-boshrelease/manifests/gogs.yml \
+  -o gogs-boshrelease/manifests/operators/ldap_auth.yml \
+  -v gogs-uri=gogs.v3.pcf.dev.io \
+  --vars-store creds.yml
+```

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,1 @@
+* Add ability to specify different authentication backends

--- a/jobs/gogs/spec
+++ b/jobs/gogs/spec
@@ -65,3 +65,47 @@ properties:
         - name: gogs
           password: MyGogsPassword
           tag: gogs
+
+  authentication:
+    description: "A list of authentication backends to add"
+    optional: true
+    example: |
+      - type:
+          name: LDAP
+          id: 101
+          type: ldap_bind_dn
+          is_activated: true
+          is_default: true
+        config:
+          host: 10.244.0.100
+          port: 389
+          security_protocol: 0
+          skip_verify: true
+          bind_dn: cn=binduser,dc=example,dc=org
+          bind_password: bindpassword
+          user_base: dc=example,dc=org
+          attribute_username: uid
+          attribute_name: givenName
+          attribute_surname: sn
+          attribute_mail: mail
+          attributes_in_bind:
+          filter: (&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))
+          admin_filter:
+          group_enabled: false
+          group_dn:
+          group_filter:
+          group_member_uid:
+          user_uid:
+      - type:
+          name: GMail
+          id: 102
+          type: smtp
+          is_activated: true
+          is_default: false
+        config:
+          auth: PLAIN
+          host: smtp.gmail.com
+          port: 587
+          allowed_domains:
+          tls: true
+          skip_verify: false

--- a/jobs/gogs/spec
+++ b/jobs/gogs/spec
@@ -69,43 +69,44 @@ properties:
   authentication:
     description: "A list of authentication backends to add"
     optional: true
-    example: |
-      - type:
-          name: LDAP
-          id: 101
-          type: ldap_bind_dn
-          is_activated: true
-          is_default: true
-        config:
-          host: 10.244.0.100
-          port: 389
-          security_protocol: 0
-          skip_verify: true
-          bind_dn: cn=binduser,dc=example,dc=org
-          bind_password: bindpassword
-          user_base: dc=example,dc=org
-          attribute_username: uid
-          attribute_name: givenName
-          attribute_surname: sn
-          attribute_mail: mail
-          attributes_in_bind:
-          filter: (&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))
-          admin_filter:
-          group_enabled: false
-          group_dn:
-          group_filter:
-          group_member_uid:
-          user_uid:
-      - type:
-          name: GMail
-          id: 102
-          type: smtp
-          is_activated: true
-          is_default: false
-        config:
-          auth: PLAIN
-          host: smtp.gmail.com
-          port: 587
-          allowed_domains:
-          tls: true
-          skip_verify: false
+    example:
+      authentication: |
+        - type:
+            name: LDAP
+            id: 101
+            type: ldap_bind_dn
+            is_activated: true
+            is_default: true
+          config:
+            host: 10.244.0.100
+            port: 389
+            security_protocol: 0
+            skip_verify: true
+            bind_dn: cn=binduser,dc=example,dc=org
+            bind_password: bindpassword
+            user_base: dc=example,dc=org
+            attribute_username: uid
+            attribute_name: givenName
+            attribute_surname: sn
+            attribute_mail: mail
+            attributes_in_bind:
+            filter: (&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))
+            admin_filter:
+            group_enabled: false
+            group_dn:
+            group_filter:
+            group_member_uid:
+            user_uid:
+        - type:
+            name: GMail
+            id: 102
+            type: smtp
+            is_activated: true
+            is_default: false
+          config:
+            auth: PLAIN
+            host: smtp.gmail.com
+            port: 587
+            allowed_domains:
+            tls: true
+            skip_verify: false

--- a/jobs/gogs/templates/bin/gogs_ctl
+++ b/jobs/gogs/templates/bin/gogs_ctl
@@ -21,6 +21,29 @@ case $1 in
 
     mkdir -p ${STORE_DIR}/{home,repositories,avatars,attachments,sessions,config,tmp}
 
+    # Remove any old authentication configs that may have been deployed
+		# This lives in the package directory as "gogs web" is run in
+    # the work directory 'cd ${PACKAGE_DIR}'
+    mkdir -p ${PACKAGE_DIR}/custom/conf/auth.d
+    rm -rf ${PACKAGE_DIR}/custom/conf/auth.d/*.conf
+
+		# Generate new configuration files
+<%- if_p('authentication') do |auths| -%>
+  <%- auths.each do |auth| -%>
+    <%- types = auth.fetch('type', []) %>
+cat << EOF > ${PACKAGE_DIR}/custom/conf/auth.d/<%= types['id'] %>.conf
+    <%- types.each_pair do |k, v| -%>
+<%= "#{k} = #{v}" %>
+    <%- end -%>
+[config]
+    <%- configs = auth.fetch('config', []) %>
+    <%- configs.each_pair do |k, v| -%>
+<%= "#{k} = #{v}" %>
+    <%- end -%>
+EOF
+  <%- end -%>
+<%- end -%>
+
     if id git >/dev/null 2>&1; then
       echo "user git exists"
     else

--- a/jobs/gogs/templates/bin/gogs_ctl
+++ b/jobs/gogs/templates/bin/gogs_ctl
@@ -27,7 +27,7 @@ case $1 in
     mkdir -p ${PACKAGE_DIR}/custom/conf/auth.d
     rm -rf ${PACKAGE_DIR}/custom/conf/auth.d/*.conf
 
-		# Generate new configuration files into the appropriate locations
+    # Generate new configuration files into the appropriate locations
     # It uses key=value pairs that match exactly what is defined in the gogs authentication examples
 <%- if_p('authentication') do |auths| -%>
   <%- auths.each do |auth| -%>

--- a/jobs/gogs/templates/bin/gogs_ctl
+++ b/jobs/gogs/templates/bin/gogs_ctl
@@ -21,13 +21,14 @@ case $1 in
 
     mkdir -p ${STORE_DIR}/{home,repositories,avatars,attachments,sessions,config,tmp}
 
-    # Remove any old authentication configs that may have been deployed
-		# This lives in the package directory as "gogs web" is run in
-    # the work directory 'cd ${PACKAGE_DIR}'
+    # Remove any old authentication configs that may have been deployed previously
+    # This lives in the package directory as "gogs web" is run in here and
+    # the custom path is based on workdir in gogs codebase
     mkdir -p ${PACKAGE_DIR}/custom/conf/auth.d
     rm -rf ${PACKAGE_DIR}/custom/conf/auth.d/*.conf
 
-		# Generate new configuration files
+		# Generate new configuration files into the appropriate locations
+    # It uses key=value pairs that match exactly what is defined in the gogs authentication examples
 <%- if_p('authentication') do |auths| -%>
   <%- auths.each do |auth| -%>
     <%- types = auth.fetch('type', []) %>

--- a/manifests/gogs.yml
+++ b/manifests/gogs.yml
@@ -86,5 +86,5 @@ releases:
   stemcell:
     os: ubuntu-xenial
     version: "250.4"
-    url: https://s3.amazonaws.com/gogs-boshrelease/compiled-releases/gogs/gogs-5.4.1-ubuntu-xenial-250.4-20190130-215403-59378592-20190130215407.tgz
-    version: 5.4.1
+  url: https://s3.amazonaws.com/gogs-boshrelease/compiled-releases/gogs/gogs-5.4.1-ubuntu-xenial-250.4-20190130-215403-59378592-20190130215407.tgz
+  version: 5.4.1

--- a/manifests/gogs.yml
+++ b/manifests/gogs.yml
@@ -86,5 +86,5 @@ releases:
   stemcell:
     os: ubuntu-xenial
     version: "250.4"
-  url: https://s3.amazonaws.com/gogs-boshrelease/compiled-releases/gogs/gogs-5.4.1-ubuntu-xenial-250.4-20190130-215403-59378592-20190130215407.tgz
-  version: 5.4.1
+    url: https://s3.amazonaws.com/gogs-boshrelease/compiled-releases/gogs/gogs-5.4.1-ubuntu-xenial-250.4-20190130-215403-59378592-20190130215407.tgz
+    version: 5.4.1

--- a/manifests/operators/ldap-auth-multiple.yml
+++ b/manifests/operators/ldap-auth-multiple.yml
@@ -1,0 +1,61 @@
+---
+- type: replace
+  path: /properties/authentication?/-
+  value:
+    type:
+      name: "LDAP BindDN"
+      id: "101"
+      type: "ldap_bind_dn"
+      is_activated: "true"
+      is_default: "true"
+    config:
+      host: "10.244.0.101"
+      port: "389"
+      security_protocol: "0"
+      skip_verify: "true"
+      bind_dn: "cn=admin,dc=pivotal,dc=org"
+      bind_password: "examplebindpass"
+      user_base: "dc=pivotal,dc=org"
+      attribute_username: uid
+      attribute_name: givenName
+      attribute_surname: sn
+      attribute_mail: mail
+      attributes_in_bind:
+      filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      admin_filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      group_enabled: "false"
+      group_dn: ""
+      group_filter: ""
+      group_member_uid: ""
+      user_uid: ""
+
+- type: replace
+  path: /properties/authentication?/-
+  value:
+    type:
+      name: "LDAP 2 BindDN"
+      id: "102"
+      type: "ldap_bind_dn"
+      is_activated: "true"
+      is_default: "false"
+    config:
+      host: "10.244.0.102"
+      port: "389"
+      security_protocol: "0"
+      skip_verify: "true"
+      bind_dn: "cn=admin,dc=example,dc=org"
+      bind_password: "examplebindpass"
+      user_base: "dc=example,dc=org"
+      attribute_username: uid
+      attribute_name: givenName
+      attribute_surname: sn
+      attribute_mail: mail
+      attributes_in_bind:
+      filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      admin_filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      group_enabled: "false"
+      group_dn: ""
+      group_filter: ""
+      group_member_uid: ""
+      user_uid: ""
+

--- a/manifests/operators/ldap-auth.yml
+++ b/manifests/operators/ldap-auth.yml
@@ -1,0 +1,30 @@
+---
+- type: replace
+  path: /properties/authentication?/-
+  value:
+    type:
+      name: "LDAP BindDN"
+      id: "101"
+      type: "ldap_bind_dn"
+      is_activated: "true"
+      is_default: "true"
+    config:
+      host: "10.244.0.101"
+      port: "389"
+      security_protocol: "0"
+      skip_verify: "true"
+      bind_dn: "cn=admin,dc=pivotal,dc=org"
+      bind_password: "examplebindpass"
+      user_base: "dc=pivotal,dc=org"
+      attribute_username: uid
+      attribute_name: givenName
+      attribute_surname: sn
+      attribute_mail: mail
+      attributes_in_bind:
+      filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      admin_filter: "(&(objectClass=inetOrgPerson)(|(uid=%s)(mail=%s)))"
+      group_enabled: "false"
+      group_dn: ""
+      group_filter: ""
+      group_member_uid: ""
+      user_uid: ""

--- a/manifests/operators/smtp-auth.yml
+++ b/manifests/operators/smtp-auth.yml
@@ -1,0 +1,16 @@
+---
+- type: replace
+  path: /properties/authentication?/-
+  value:
+    type:
+      name: "GMail"
+      id: "103"
+      type: "smtp"
+      is_activated: "true"
+      is_default: "false"
+    config:
+      auth: PLAIN
+      host: smtp.gmail.com
+      port: 587
+      allowed_domains:
+      tls: true


### PR DESCRIPTION
This PR adds the ability to specify different authentication backends for gogs.

This is handy if you already have a user base in LDAP or other supported backend, allowing you to deploy gogs and quickly have your users able to log in.

It also means if you are using a config server like credhub, you can rotate credentials easily without having to log in to gogs and manually update them.